### PR TITLE
chore(deps): Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,9 +406,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -510,7 +510,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",

--- a/src/priority_map.rs
+++ b/src/priority_map.rs
@@ -85,7 +85,7 @@ impl<K: Eq + Hash + Clone + Debug, V: Debug> PriorityMap<K, V> {
 
     #[allow(unused)]
     pub fn contains_key(&self, key: &K) -> bool {
-        self.data.get(key).is_some()
+        self.data.contains_key(key)
     }
 
     pub fn check_prune(&mut self) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -89,7 +89,6 @@ pub enum UriPathSegmentMatcher {
 }
 
 impl UriPathSegmentMatcher {
-    ///
     pub fn new(segment: &str) -> Result<UriPathSegmentMatcher, String> {
         if segment.contains('/') {
             return Err("A path segment should not contain any /".to_string());
@@ -132,7 +131,6 @@ impl UriPathSegmentMatcher {
         }
     }
 
-    ///
     pub fn matches(&self, other: &str) -> bool {
         match self {
             UriPathSegmentMatcher::Static { segment: ref s } => s.eq(other),
@@ -170,9 +168,8 @@ pub enum RequestContinuation {
 
 /// Trait to convert string type to regular expressions
 pub trait ToRegex {
-    ///
     fn to_regex(&self) -> Result<::regex::Regex, ::regex::Error>;
-    ///
+
     fn as_str(&self) -> &str;
 }
 


### PR DESCRIPTION
Updated h2from `0.3.24` to `0.3.26`
Updated mio from `0.8.10` to `0.8.11`

Resolves the following dependabot alerts : 
https://github.com/Devolutions/prux/security/dependabot/15
https://github.com/Devolutions/prux/security/dependabot/16